### PR TITLE
Dockerfile + SetAttr Bug Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial-20161114 as build
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install make gcc libtirpc-dev libncurses-dev libreadline-dev -y
+COPY ./ /nfsshell
+WORKDIR /nfsshell
+RUN make
+
+FROM ubuntu:xenial-20161114
+COPY --from=build /nfsshell/nfsshell /bin/nfsshell
+ENTRYPOINT ["/bin/nfsshell"]

--- a/nfsshell.c
+++ b/nfsshell.c
@@ -1161,6 +1161,8 @@ do_chmod(int argc, char **argv)
     aargs.new_attributes.atime = (set_atime) { .set_it=FALSE };
     aargs.new_attributes.mtime = (set_mtime) { .set_it=FALSE };
 
+    aargs.guard.check = FALSE;
+
     if ((ares = nfs3_setattr_3(&aargs, nfsclient)) == NULL) {
 	clnt_perror(nfsclient, "nfs3_setattr");
 	return;
@@ -1273,6 +1275,8 @@ do_chown(int argc, char **argv)
     aargs.new_attributes.size  = (set_size3) { .set_it=FALSE };
     aargs.new_attributes.atime = (set_atime) { .set_it=FALSE };
     aargs.new_attributes.mtime = (set_mtime) { .set_it=FALSE };
+
+    aargs.guard.check = FALSE;
 
     if ((ares = nfs3_setattr_3(&aargs, nfsclient)) == NULL) {
 	clnt_perror(nfsclient, "nfs3_setattr");


### PR DESCRIPTION
The RPC dependencies are a bit old, so a Dockerfile was added to allow for nfsshell to continue working on newer systems via a container.

To build:
```
docker build -t nfsshell:latest .
```

To run:
```
docker run --network=host -it nfsshell:latest
```

----

For newer NFS shares, I noticed that I was getting a corrupt packet whenever the setattr methods were used. The guard property on the SETATTR3args object did not set the check property. I set this to a default of false. The definition can be seen here: https://datatracker.ietf.org/doc/html/rfc1813#section-3.3.2